### PR TITLE
Round Start Countdown

### DIFF
--- a/Missile Champions/MChamps.h
+++ b/Missile Champions/MChamps.h
@@ -86,12 +86,20 @@ private:
 	SDL_Rect* Minute1sRect;
 	SDL_Rect* Second10sRect;
 	SDL_Rect* Second1sRect;
+	Assets::Image* Countdown321;
+	SDL_Rect* Countdown321Rect;
+	Assets::Image* CountdownG;
+	SDL_Rect* CountdownGRect;
+	Assets::Image* CountdownO;
+	SDL_Rect* CountdownORect;
+
 	Assets::Image*	BoostBar;
 	SDL_Rect*		BoostBarScaleRect;
 	Car* drawCars[6];
 
 	Timer	MusicTimer;
 	Timer	ShadowBlinkTimer;
+	Timer	RoundStartTimer;
 	Timer	RoundTimer;
 
 	// Events and effects

--- a/Missile Champions/OnCleanup.cpp
+++ b/Missile Champions/OnCleanup.cpp
@@ -1,6 +1,23 @@
 #include "MChamps.h"
 
 void MChamps::OnCleanup() {
+	Mix_FreeChunk(mAssets->sounds.Boost);
+	Mix_FreeChunk(mAssets->sounds.Engine);
+	Mix_FreeChunk(mAssets->sounds.MoveCursor);
+	Mix_FreeChunk(mAssets->sounds.Selection);
+	Mix_FreeChunk(mAssets->sounds.StartSelection);
+	Mix_FreeMusic(mAssets->music.CarSelection);
+	Mix_FreeMusic(mAssets->music.Eurobeat);
+	Mix_FreeMusic(mAssets->music.Title);
+	mAssets->sounds.Boost = NULL;
+	mAssets->sounds.Engine = NULL;
+	mAssets->sounds.MoveCursor = NULL;
+	mAssets->sounds.Selection = NULL;
+	mAssets->sounds.StartSelection = NULL;
+	mAssets->music.CarSelection = NULL;
+	mAssets->music.Eurobeat = NULL;
+	mAssets->music.Title = NULL;
+
 	Mix_Quit();
 	
 	Graphics::Release();

--- a/Missile Champions/OnEvent.cpp
+++ b/Missile Champions/OnEvent.cpp
@@ -72,6 +72,7 @@ void MChamps::OnEvent(SDL_Event* Event) {
 			if (Event->key.keysym.sym == SDLK_ESCAPE) {
 				Mix_VolumeMusic(MIX_MAX_VOLUME);
 				Mix_HaltMusic();
+				RoundTimer.stop();
 				CurrentScene = Scene_TitleScreen;
 			}
 			break;			

--- a/Missile Champions/OnInit.cpp
+++ b/Missile Champions/OnInit.cpp
@@ -67,6 +67,13 @@ bool MChamps::OnInit() {
 		mAssets->images.BoostF1Sprite[i] = { Assets::Instance()->GetTexture(IMAGE_BOOST_F1_SPRITE_SHEET), Graphics::CreateRect(32, 32, 32 * i, 0) };
 		mAssets->images.BoostF2Sprite[i] = { Assets::Instance()->GetTexture(IMAGE_BOOST_F2_SPRITE_SHEET), Graphics::CreateRect(32, 32, 32 * i, 0) };
 	}
+	// Countdown Timer
+	Countdown321 = NULL;
+	Countdown321Rect = Graphics::CreateRect(8, 8, 124, 100);
+	CountdownG = NULL;
+	CountdownGRect = Graphics::CreateRect(8, 8, 120, 100);
+	CountdownO = NULL;
+	CountdownORect = Graphics::CreateRect(8, 8, 128, 100);
 	
 	//// Effects
 	Effect_StartFlashLength = 0;

--- a/Missile Champions/OnRender.cpp
+++ b/Missile Champions/OnRender.cpp
@@ -116,6 +116,16 @@ void MChamps::OnRender() {
 		BoostBarScaleRect->w = (int)(64.0 * ((double)Players[0].activeCar->boostFuel / (double)MAX_BOOST_FUEL));
 		DrawImage(BoostBar, BoostBarScaleRect);
 
+		// Draw countdown numbers
+		if (Countdown321 != NULL) {
+			DrawImage(Countdown321, Countdown321Rect);
+		}
+
+		if (CountdownG != NULL) {
+			DrawImage(CountdownG, CountdownGRect);
+			DrawImage(CountdownO, CountdownORect);
+		}
+		
 		break;
 	}
 


### PR DESCRIPTION
- Round now starts with a countdown in OnLoop.cpp. Gameplay will not commence until the countdown finishes.
- Round timers added to MChamps.h.
- Round timer graphics implemented in OnInit.cpp, OnLoop.cpp, OnRender.cpp.
- Round timer stops when exiting to Title in OnEvent.cpp. Before this would cause a game to be in progress when starting a new game.
-- Janitorial
- Removed volume set funcs from OnLoop.cpp.
- Added clean funcs to OnCleanup.cpp for sound assets. Forgot to clear them out, whooooops.