### PR TITLE
Timer stop()s added to end of Credits/Game Over

### DIFF
--- a/Missile Champions/OnLoop.cpp
+++ b/Missile Champions/OnLoop.cpp
@@ -102,6 +102,7 @@ void MChamps::OnLoop() {
 		}
 
 		if (creditsTicks > 102000) {
+			CreditsTimer.stop();
 			CurrentScene = Scene_TitleScreen;
 		}
 		break;
@@ -111,6 +112,7 @@ void MChamps::OnLoop() {
 			GameOverTimer.start();
 		}
 		if (GameOverTimer.getTicks() > 5000) {
+			GameOverTimer.stop();
 			CurrentScene = Scene_TitleScreen;
 		}
 		break;


### PR DESCRIPTION
- Timers for Credits and Game Over screend did not stop if ended by waiting. CreditsTimer.stop() and GameOverTimer.stop() added to respective scenes in OnLoop.cpp.