### PR TITLE
Allow buffered car input during countdown

### DIFF
--- a/Missile Champions/OnEvent.cpp
+++ b/Missile Champions/OnEvent.cpp
@@ -51,24 +51,22 @@ void MChamps::OnEvent(SDL_Event* Event) {
 			break;
 
 		case Scene_Gameplay:
-			if (RoundTimer.isStarted() && !RoundTimer.isPaused()) {
-				// Active car control events
-				if (Event->key.keysym.sym == SDLK_UP)
-					Players[0].activeCar->MoveDirection = Car::Forward;
-				if (Event->key.keysym.sym == SDLK_DOWN)
-					Players[0].activeCar->MoveDirection = Car::Backward;
-				if (Event->key.keysym.sym == SDLK_LEFT)
-					Players[0].activeCar->Turning = Car::Left;
-				if (Event->key.keysym.sym == SDLK_RIGHT)
-					Players[0].activeCar->Turning = Car::Right;
-				// Change active car event
-				if (Event->key.keysym.sym == SDLK_x && Event->key.repeat == 0)
-					Event_ChangeCar = true;
-				if (Event->key.keysym.sym == SDLK_z)
-					Players[0].activeCar->isBoosting = true;
-				if (Event->key.keysym.sym == SDLK_SPACE && Players[0].activeCar->z <= 0 && Event->key.repeat == 0)
-					Players[0].activeCar->isJumping = true;
-			}
+			// Active car control events
+			if (Event->key.keysym.sym == SDLK_UP)
+				Players[0].activeCar->MoveDirection = Car::Forward;
+			if (Event->key.keysym.sym == SDLK_DOWN)
+				Players[0].activeCar->MoveDirection = Car::Backward;
+			if (Event->key.keysym.sym == SDLK_LEFT)
+				Players[0].activeCar->Turning = Car::Left;
+			if (Event->key.keysym.sym == SDLK_RIGHT)
+				Players[0].activeCar->Turning = Car::Right;
+			// Change active car event
+			if (Event->key.keysym.sym == SDLK_x && Event->key.repeat == 0)
+				Event_ChangeCar = true;
+			if (Event->key.keysym.sym == SDLK_z)
+				Players[0].activeCar->isBoosting = true;
+			if (Event->key.keysym.sym == SDLK_SPACE && Players[0].activeCar->z <= 0 && Event->key.repeat == 0)
+				Players[0].activeCar->isJumping = true;
 			// Exit to title screen
 			if (Event->key.keysym.sym == SDLK_ESCAPE) {
 				Mix_VolumeMusic(MIX_MAX_VOLUME);


### PR DESCRIPTION
-- OnEvent.cpp
- A temporary fix was leftover when the countdown timer was not working properly. That killed buffering input while halted during the countdown, which disallowed pre-buffering movement. The old fix was removed and has now fixed this.