### PR TITLE
Remove stale boost streak sprites when car resets

### DIFF
--- a/Missile Champions/Objects/Car.cpp
+++ b/Missile Champions/Objects/Car.cpp
@@ -90,6 +90,7 @@ void Car::SetCarKickoff(int team, int carpos) {
 		this->anglesprite = 12;
 		break;
 	}
+	for (int i = 0; i < 5; i++) this->streak[i].timeAlive = 0;
 	this->image = &this->assets->images.CarSprites[this->anglesprite][team];
 	this->dx = sin(this->angle * M_PI / 180.0);
 	this->dy = cos(this->angle * M_PI / 180.0);


### PR DESCRIPTION
- Boost streak sprites would remain on the field after a goal was scored due to not having their timeAlive attribute set to 0. They are now all set to 0 when car is reset, Car.cpp.